### PR TITLE
Feature/extension in get server name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# For more information about the properties used in
+# this file, please see the EditorConfig documentation:
+# http://editorconfig.org/
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,7 @@ php:
   - 5.5
   - 5.6
 env:
-  - DB=MYSQL CORE_RELEASE=3.2
-
-matrix:
-  include:
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.3
+  - DB=MYSQL CORE_RELEASE=3
 
 before_script:
   - composer self-update || true

--- a/code/CloudFlare.php
+++ b/code/CloudFlare.php
@@ -301,19 +301,24 @@ class CloudFlare extends Object
      */
     public function getServerName()
     {
-        $replaceWith = array(
-            'www.'     => '',
-            'http://'  => '',
-            'https://' => ''
-        );
-
-        $server = \Convert::raw2xml($_SERVER); // "Fixes" #1
-        $serverName = str_replace(array_keys($replaceWith), array_values($replaceWith), $server['SERVER_NAME']);
+        $serverName = '';
+        if (!empty($_SERVER['SERVER_NAME'])) {
+            $server = \Convert::raw2xml($_SERVER); // "Fixes" #1
+            $serverName = $server['SERVER_NAME'];
+        }
 
         // CI support
         if (getenv('TRAVIS')) {
             $serverName = getenv('CLOUDFLARE_DUMMY_SITE');
         }
+
+        // Remove protocols, etc
+        $replaceWith = array(
+            'www.'     => '',
+            'http://'  => '',
+            'https://' => ''
+        );
+        $serverName = str_replace(array_keys($replaceWith), array_values($replaceWith), $serverName);
 
         // Allow extensions to modify or replace the server name if required
         $this->extend('updateCloudFlareServerName', $serverName);

--- a/code/CloudFlare.php
+++ b/code/CloudFlare.php
@@ -14,17 +14,12 @@ class CloudFlare extends Object
     protected static $ready = false;
 
     /**
-     * @var \CloudFlare
-     */
-    protected static $singleton;
-
-    /**
-     * Instance
+     * Get a singleton instance. Use the default Object functionality
      * @return \CloudFlare
      */
     public static function inst()
     {
-        return (is_object(static::$singleton)) ? static::$singleton : static::$singleton = new CloudFlare();
+        return self::singleton();
     }
 
     /**

--- a/tests/CloudFlareTest.php
+++ b/tests/CloudFlareTest.php
@@ -1,29 +1,67 @@
 <?php
-
 /**
- * @todo
  * Class CloudFlareTest
+ *
+ * @todo
+ * @coversDefaultClass CloudFlare
  */
-class CloudFlareTest extends SapphireTest {
-
+class CloudFlareTest extends SapphireTest
+{
     /**
-     * Tests CloudFlare::inst()->getUrlVariants()
+     * @covers ::getUrlVariants
      */
-    public function testGetUrlVariants() {
+    public function testGetUrlVariants()
+    {
         $urls = array(
-            "http://www.example.com",
+            'http://www.example.com',
         );
-        
+
         $this->assertEquals(
             CloudFlare::inst()->getUrlVariants($urls),
             array(
-                "http://www.example.com",
-                "https://www.example.com",
-                "http://www.example.com?stage=Stage",
-                "https://www.example.com?stage=Stage"
+                'http://www.example.com',
+                'https://www.example.com',
+                'http://www.example.com?stage=Stage',
+                'https://www.example.com?stage=Stage'
             )
         );
     }
-    
 
+    /**
+     * Ensures that the server name can be retrieved as expected from server super global, environment variables
+     * or an extension attached
+     * @covers ::getServerName
+     */
+    public function testGetServerName()
+    {
+        // Ensures that protocols etc are removed
+        $_SERVER['SERVER_NAME'] = 'https://www.sometest.dev';
+        $this->assertSame('sometest.dev', CloudFlare::inst()->getServerName());
+
+        // Ensures that the CI environment can be factored in
+        putenv('TRAVIS=1');
+        putenv('CLOUDFLARE_DUMMY_SITE=anothertest.dev');
+        $this->assertSame('anothertest.dev', CloudFlare::inst()->getServerName());
+
+        // Apply a test extension, get a new instance of the CF class and test again to ensure the hook works
+        CloudFlare::add_extension('CloudFlareTest_Extension');
+        $this->assertSame('extended.dev', CloudFlare::create()->getServerName());
+    }
+}
+
+/**
+ * A stub extension applied to CloudFlare as needed to test extension hooks
+ */
+class CloudFlareTest_Extension extends Extension implements TestOnly
+{
+    /**
+     * Set a dummy server name
+     *
+     * @see CloudFlare::getServerName
+     * @var string $serverName
+     */
+    public function updateCloudFlareServerName(&$serverName)
+    {
+        $serverName = 'extended.dev';
+    }
 }

--- a/tests/CloudFlareTest.php
+++ b/tests/CloudFlareTest.php
@@ -28,20 +28,15 @@ class CloudFlareTest extends SapphireTest
     }
 
     /**
-     * Ensures that the server name can be retrieved as expected from server super global, environment variables
-     * or an extension attached
+     * Ensures that the server name can be retrieved as expected from environment variables or an extension attached
      * @covers ::getServerName
      */
     public function testGetServerName()
     {
-        // Ensures that protocols etc are removed
-        $_SERVER['SERVER_NAME'] = 'https://www.sometest.dev';
-        $this->assertSame('sometest.dev', CloudFlare::inst()->getServerName());
-
-        // Ensures that the CI environment can be factored in
+        // Ensures the CI environment can be factored in
         putenv('TRAVIS=1');
-        putenv('CLOUDFLARE_DUMMY_SITE=anothertest.dev');
-        $this->assertSame('anothertest.dev', CloudFlare::inst()->getServerName());
+        putenv('CLOUDFLARE_DUMMY_SITE=https://www.sometest.dev');
+        $this->assertSame('sometest.dev', CloudFlare::inst()->getServerName());
 
         // Apply a test extension, get a new instance of the CF class and test again to ensure the hook works
         CloudFlare::add_extension('CloudFlareTest_Extension');


### PR DESCRIPTION
Commit 416f562 may not merge once #8 is merged - is here to ensure the build passes.

* Add extension hook to `getServerName` method to allow modules to contribute to the server name/Zone ID retrieval
* Add test for `getServerName`
* Make `CloudFlare` extend `Object` so it can be extensible
* Add EditorConfig file
* Replace instance factory method (`inst`) with `Object::singleton` in a backward compatible fashioon

---

Resolves #9 