### PR TITLE
API Add purge action to Pages in CMS

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -8,3 +8,6 @@ After:
 SiteTree:
   extensions:
     - CloudFlareExt
+LeftAndMain:
+  extensions:
+    - CloudFlareLeftAndMainExtension

--- a/code/CloudFlare.php
+++ b/code/CloudFlare.php
@@ -92,6 +92,22 @@ class CloudFlare extends Object
     }
 
     /**
+     * Purge a specific SiteTree instance, or by its ID
+     *
+     * @param  SiteTree|int $pageOrId
+     * @return bool
+     */
+    public function purgePage($pageOrId)
+    {
+        if (!($pageOrId instanceof SiteTree)) {
+            $pageOrId = DataObject::get_by_id('SiteTree', $pageOrId);
+        }
+        $page = $pageOrId;
+
+        return $this->purgeSingle($page->Link());
+    }
+
+    /**
      * Same as purgeSingle with the obvious functionality to handle many
      *
      * @param array $filesOrUrls

--- a/code/extensions/CloudFlareExt.php
+++ b/code/extensions/CloudFlareExt.php
@@ -1,11 +1,11 @@
 <?php
-
 /**
  * Class CloudFlareExt
+ *
+ * @package silverstripe-cloudflare
  */
 class CloudFlareExt extends SiteTreeExtension
 {
-
     /**
      * Extension Hook
      *
@@ -123,5 +123,21 @@ class CloudFlareExt extends SiteTreeExtension
         }
     }
 
+    /**
+     * Add a "purge page" CMS action
+     *
+     * @param  FieldList $actions
+     * @return void
+     */
+    public function updateCMSActions(FieldList $actions)
+    {
+        if (!CloudFlare::inst()->hasCFCredentials()) {
+            return;
+        }
 
+        $actions->addFieldToTab(
+            'ActionMenus.MoreOptions',
+            FormAction::create('purgesinglepageAction', 'Purge in CloudFlare')
+        );
+    }
 }

--- a/code/extensions/CloudFlareLeftAndMainExtension.php
+++ b/code/extensions/CloudFlareLeftAndMainExtension.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class CloudFlareLeftAndMainExtension
+ *
+ * @package silverstripe-cloudflare
+ */
+class CloudFlareLeftAndMainExtension extends LeftAndMainExtension
+{
+    /**
+     * {@inheritDoc}
+     */
+    private static $allowed_actions = array(
+        'purgesinglepage'
+    );
+
+    /**
+     * Purge a single page in CloudFlare
+     *
+     * @param array $request The SiteTree data requested to be purged
+     */
+    public function purgesinglepageAction($request)
+    {
+        if (empty($request) || empty($request['ID'])) {
+            return;
+        }
+
+        CloudFlare::inst()->purgePage($request['ID']);
+    }
+}


### PR DESCRIPTION
Add a "Purge in CloudFlare" action to the menu while editing a Page in the CMS:

![Example](https://cloud.githubusercontent.com/assets/5170590/21031798/44f51212-be0a-11e6-8748-73656bd802e4.png)


Resolves #14