### PR TITLE
WIP: Page Rules Implementation

### DIFF
--- a/code/Rules/Items/Actions/RuleAction.php
+++ b/code/Rules/Items/Actions/RuleAction.php
@@ -1,0 +1,90 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Object;
+
+class RuleAction extends Object
+{
+    /**
+     * This represents the action that the inheriting page rule should trigger, ie: cache_level, browser_cache_ttl,
+     * rocket_loader etc
+     *
+     * @var string
+     */
+    protected $actionId;
+
+    /**
+     * @var int|string This value is dependent on the action
+     */
+    protected $value;
+
+    /**
+     * Sets the action id, ie: cache_level, browser_cache_ttl, rocket_loader etc
+     *
+     * @param string $actionId
+     *
+     * @return $this
+     */
+    public function setActionId($actionId)
+    {
+        $this->actionId = $actionId;
+
+        return $this;
+    }
+
+    /**
+     * Gets the action id
+     *
+     * @return string
+     */
+    public function getActionId()
+    {
+        return $this->actionId;
+    }
+
+    /**
+     * Set the value for this objects action id
+     *
+     * @param int|string $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of this objects action id
+     *
+     * @return int|string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Converts this object to an array in the format expected by CloudFlare
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            'id'    => $this->getActionId(),
+            'value' => $this->getValue()
+        );
+    }
+
+    /**
+     * Converts this object to a JSON string in the format expected by CloudFlare
+     *
+     * @return array
+     */
+    public function toJson() {
+        return json_encode($this->toArray());
+    }
+}

--- a/code/Rules/Items/Actions/RuleActionList.php
+++ b/code/Rules/Items/Actions/RuleActionList.php
@@ -1,0 +1,52 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Object;
+
+class RuleActionList extends Object
+{
+    /**
+     * @var array An array of RuleAction's
+     */
+    protected $items = array();
+
+    /**
+     * Pushes a RuleAction object into this object
+     *
+     * @param \Steadlane\CloudFlare\Rules\RuleAction $item
+     */
+    public function push(RuleAction $item)
+    {
+        if (in_array($item, $this->items)) {
+            return;
+        }
+
+        $this->items[] = $item;
+    }
+
+    /**
+     * Converts all children of this object into an array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $stack = array();
+
+        foreach ($this->items as $item) {
+            $stack[] = $item->toArray();
+        }
+
+        return $stack;
+    }
+
+    /**
+     * Converts all children of this object into an array and outputs it as JSON
+     *
+     * @return string
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/code/Rules/Items/RuleItem.php
+++ b/code/Rules/Items/RuleItem.php
@@ -1,0 +1,332 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Object;
+use Steadlane\CloudFlare\CloudFlare;
+
+class RuleItem extends Object
+{
+
+    /**
+     * @var RuleTargetList
+     */
+    protected $targets;
+
+    /**
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * @var RuleActionList
+     */
+    protected $actions;
+
+    /**
+     * @var int
+     */
+    protected $priority;
+
+    /**
+     * @var bool
+     */
+    protected $status;
+
+    /**
+     * @var string
+     */
+    protected $createdOn;
+
+    /**
+     * @var string
+     */
+    protected $modifiedOn;
+
+    /**
+     * @var bool
+     */
+    protected $hasError = false;
+
+    /**
+     * @var array
+     */
+    protected $errorMessage;
+
+    /**
+     * Loads this object with data from source, expects a single rule in either JSON string format or an array,
+     * in the format it was delivered in.
+     *
+     * @param string|array $source
+     *
+     * @return $this
+     */
+    public function load($source)
+    {
+
+        if (!is_string($source) && !is_array($source)) {
+            user_error('RuleItem::load() must be provided a JSON string or an array', E_USER_ERROR);
+        }
+
+        if (is_string($source)) {
+            $source = json_decode($source, true);
+            if (!is_array($source)) {
+                user_error('RuleItem::load() must be provided a JSON string or an array', E_USER_ERROR);
+            }
+        }
+
+        if (array_key_exists(0, $source) && is_array($source[0])) {
+            user_error('RuleItem::load() expects only a single item', E_USER_ERROR);
+        }
+
+        $targetList = RuleTargetList::create();
+        foreach ($source['targets'] as $target) {
+            $targetList->push(RuleTarget::create()
+                ->setTarget($target['target'])
+                ->setOperator('matches')
+                ->setValue($target['constraint']['value'])
+            );
+        }
+
+        $actionList = RuleActionList::create();
+        foreach ($source['actions'] as $action) {
+            $actionList->push(RuleAction::create()
+                ->setActionId($action['id'])
+                ->setValue($action['value'])
+            );
+        }
+
+        $this->identifier = $source['id'];
+        $this->targets    = $targetList;
+        $this->actions    = $actionList;
+        $this->priority   = $source['priority'];
+        $this->status     = ($source['status'] == 'active');
+        $this->createdOn  = $source['created_on'];
+        $this->modifiedOn = $source['modified_on'];
+
+        return $this;
+    }
+
+    /**
+     * Used to update or create a new page rule, the difference is based on whether or not `$this->identifier` is set
+     *
+     * @return string|bool Returns the identifier on success
+     */
+    public function save()
+    {
+        $data = $this->toArray();
+
+        unset($data['id']); // remove ID from data as if it exists; the endpoint is updated with it dynamically
+
+        $json = CloudFlare::singleton()->curlRequest(
+            $this->getEndpoint(),
+            $data,
+            'PUT'
+        );
+
+        $result = json_decode($json, true);
+
+        if (!$result['success']) {
+            $this->hasError     = true;
+            $this->errorMessage = $result['errors'];
+
+            return false;
+        }
+
+        $this->identifier = $result['result']['id'];
+        RuleHandler::flush();
+
+        return $this->identifier;
+
+    }
+
+    /**
+     * Delete the active page rule
+     *
+     * @return bool
+     */
+    public function delete()
+    {
+        if (!$this->identifier) {
+            return true;
+        }
+
+        $json   = CloudFlare::singleton()->curlRequest($this->getEndpoint());
+        $result = json_decode($json, true);
+
+        if (!$result['success']) {
+            $this->hasError     = true;
+            $this->errorMessage = $result['errors'];
+
+            return false;
+        }
+
+        unset($this->identifier);
+        RuleHandler::flush();
+
+        return true;
+    }
+
+    /**
+     * Get the identifier for the active page rule
+     * @return string|null
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Gets the list of targets
+     *
+     * @return array|null
+     */
+    public function getTargets()
+    {
+        return $this->targets;
+    }
+
+    /**
+     * Sets the list of targets
+     *
+     * @param $targets
+     *
+     * @return $this
+     */
+    public function setTargets($targets)
+    {
+        foreach ($targets as $target) {
+            if (!($target instanceof RuleTarget)) {
+                user_error('setTargets() only accepts an array of RuleTarget\'s, one of the values was of type ' . gettype($target),
+                    E_USER_ERROR);
+            }
+        }
+        $this->targets = $targets;
+
+        return $this;
+    }
+
+    /**
+     * Gets the list of actions that is (or is tobe) placed against this page rule
+     *
+     * @return array An array of RuleAction's
+     */
+    public function getActions()
+    {
+        return $this->actions;
+    }
+
+    /**
+     * @param $actions
+     *
+     * @return $this
+     */
+    public function setActions($actions)
+    {
+        foreach ($actions as $action) {
+            if (!($action instanceof RuleTarget)) {
+                user_error('setActions() only accepts an array of RuleTarget\'s, one of the values was of type ' . gettype($action),
+                    E_USER_ERROR);
+            }
+        }
+
+        $this->actions = $actions;
+
+        return $this;
+    }
+
+    /**
+     * Get priority
+     *
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * Set Priority
+     *
+     * @param int $priority
+     *
+     * @return $this
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Get Status
+     *
+     * @return bool
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Set status
+     *
+     * @param bool $bool
+     *
+     * @return $this
+     */
+    public function setStatus($bool)
+    {
+        $this->status = $bool;
+
+        return $this;
+    }
+
+    /**
+     * Converts this object to an array in the format expected by CloudFlare
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+
+        $output = array(
+            'targets'  => $this->targets->toArray(),
+            'actions'  => $this->actions->toArray(),
+            'priority' => (int)$this->priority,
+            'status'   => ($this->status) ? 'active' : 'disabled'
+        );
+
+        if (isset($this->identifier)) {
+            $output = array_merge(array('id' => $this->identifier), $output);
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a JSON string in the format expected by CloudFlare
+     *
+     * @return array
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+
+    /**
+     * Gets the dynamic endpoint. Appends the rule identifier if the current object represents a rule
+     * that already exists in CloudFlare
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        $endpoint = rtrim(RuleHandler::singleton()->getEndpoint(), '/');
+        if ($this->identifier) {
+            $endpoint = $endpoint . '/' . $this->identifier;
+        }
+
+        return $endpoint;
+    }
+}

--- a/code/Rules/Items/RuleItemList.php
+++ b/code/Rules/Items/RuleItemList.php
@@ -1,0 +1,52 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Object;
+
+class RuleItemList extends Object
+{
+    /**
+     * @var array An array of `RuleItem`'s
+     */
+    protected $items = array();
+
+    /**
+     * Pushes a RuleItem object into this object
+     *
+     * @param \Steadlane\CloudFlare\Rules\RuleItem $item
+     */
+    public function push(RuleItem $item)
+    {
+        if (in_array($item, $this->items)) {
+            return;
+        }
+
+        $this->items[] = $item;
+    }
+
+    /**
+     * Converts all children of this object into an array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $stack = array();
+
+        foreach ($this->items as $item) {
+            $stack[] = $item->toArray();
+        }
+
+        return $stack;
+    }
+
+    /**
+     * Converts all children of this object into an array and outputs it as JSON
+     *
+     * @return string
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/code/Rules/Items/Targets/RuleTarget.php
+++ b/code/Rules/Items/Targets/RuleTarget.php
@@ -1,0 +1,125 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Object;
+
+class RuleTarget extends Object
+{
+
+    /**
+     * The target of this object. Default: "url"
+     *
+     * @var string
+     */
+    protected $target = "url";
+
+    /**
+     * @var string
+     */
+    protected $operator = "matches";
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * The value of this target
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets the value for this target; which is what the inheriting page rule will trigger against
+     *
+     * @example *.example.com/*
+     *
+     * @param string $value Usually a domain mask
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Gets the matching operator, by default "match"
+     * @return string
+     */
+    public function getOperator()
+    {
+        return $this->operator;
+    }
+
+    /**
+     * Sets the matching operator. Default: "match"
+     *
+     * @param string $operator
+     *
+     * @return $this
+     */
+    public function setOperator($operator)
+    {
+        $this->operator = $operator;
+
+        return $this;
+    }
+
+    /**
+     * Gets the target of this object. Default: "url"
+     *
+     * @return string
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * Sets the target of this object. Default: "url"
+     *
+     * @param string $target
+     *
+     * @return $this
+     */
+    public function setTarget($target)
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    /**
+     * Converts this object to an array in the format expected by CloudFlare
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            "target"     => $this->getTarget(),
+            "constraint" => array(
+                "operator" => $this->getOperator(),
+                "value"    => $this->getValue()
+            )
+        );
+    }
+
+    /**
+     * Converts this object to a JSON string in the format expected by CloudFlare
+     *
+     * @return array
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+
+}

--- a/code/Rules/Items/Targets/RuleTargetList.php
+++ b/code/Rules/Items/Targets/RuleTargetList.php
@@ -1,0 +1,52 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Object;
+
+class RuleTargetList extends Object
+{
+    /**
+     * @var array
+     */
+    protected $items = array();
+
+    /**
+     * Pushes a RuleTarget object into this object
+     *
+     * @param \Steadlane\CloudFlare\Rules\RuleTarget $item
+     */
+    public function push(RuleTarget $item)
+    {
+        if (in_array($item, $this->items)) {
+            return;
+        }
+
+        $this->items[] = $item;
+    }
+
+    /**
+     * Converts all children of this object into an array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $stack = array();
+
+        foreach ($this->items as $item) {
+            $stack[] = $item->toArray();
+        }
+
+        return $stack;
+    }
+
+    /**
+     * Converts all children of this object into an array and outputs it as JSON
+     *
+     * @return string
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/code/Rules/RuleHandler.php
+++ b/code/Rules/RuleHandler.php
@@ -1,0 +1,104 @@
+<?php
+namespace Steadlane\CloudFlare\Rules;
+
+use SilverStripe\Core\Cache;
+use SilverStripe\Core\Flushable;
+use SilverStripe\Core\Object;
+use Steadlane\CloudFlare\CloudFlare;
+
+class RuleHandler extends Object implements Flushable
+{
+    /**
+     * The cache key that page rules are stored under
+     */
+    const CF_PAGERULES_CACHE_KEY = 'CFPageRules';
+
+    /**
+     * @var string
+     */
+    protected $successMessage;
+
+    /**
+     * @var string
+     */
+    protected $failureMessage;
+
+    /**
+     * @var bool
+     */
+    protected $testOnly = false;
+
+    /**
+     * @var string
+     */
+    protected $testResultSuccess;
+
+    /**
+     * @var
+     */
+    protected $response;
+
+    /**
+     * @var string
+     */
+    protected static $endpoint = "https://api.cloudflare.com/client/v4/zones/:identifier/pagerules";
+
+    /**
+     * Gets the list of all active page rules, currently does not support pagination
+     *
+     * @return RuleItemList
+     */
+    public function getList()
+    {
+        $cacheFactory = Cache::factory('CloudFlare');
+
+        if ($cache = $cacheFactory->load(static::CF_PAGERULES_CACHE_KEY)) {
+            $json = $cache;
+        }
+
+        if (!isset($json) || $json) {
+            $json = CloudFlare::singleton()->curlRequest(
+                $this->getEndpoint(),
+                array(
+                    'status'    => 'active',
+                    'order'     => 'priority',
+                    'direction' => 'desc',
+                    'match'     => 'all'
+                ),
+                'GET'
+            );
+
+            Cache::set_cache_lifetime('CloudFlare', 60 * 30);
+            $cacheFactory->save($json, static::CF_PAGERULES_CACHE_KEY);
+        }
+
+        $array = json_decode($json, true);
+        $rules = $array['result'];
+
+        $list  = RuleItemList::create();
+        foreach ($rules as $rule) {
+            $list->push(RuleItem::create()->load($rule));
+        }
+
+        return $list;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        $zoneId = CloudFlare::singleton()->fetchZoneID();
+
+        return str_replace(":identifier", $zoneId, static::$endpoint);
+    }
+
+    /**
+     * Invalidates the cache, usually called after making a change to a rule
+     *
+     * @return bool
+     */
+    public static function flush() {
+        return Cache::factory('CloudFlare')->remove(static::CF_PAGERULES_CACHE_KEY);
+    }
+}


### PR DESCRIPTION
This PR introduces Page Rule handling.

Primarily intended to ensure that you have Page Rules setup correctly for any SilverStripe project, you can also control your page rules. You can enable or disable page rules all without leaving the SilverStripe Administration Panel

Other module developers will be able to suggest recommended page rules via a YAML file in their _config folder

While the API provides everything you could need to create and edit page rules, it's outside the scope of this project and I implore others to create extensions, submit a PR if you want to see it.