### PR TITLE
FIX: Add support for PHP 7.2+

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,7 @@
+<?php
+
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/CloudFlare.php
+++ b/code/CloudFlare.php
@@ -1,6 +1,6 @@
 <?php
 
-class CloudFlare extends Object
+class CloudFlare extends SS_Object
 {
     /**
      * @var string
@@ -441,7 +441,7 @@ class CloudFlare extends Object
     {
         Deprecation::notice('2.0', 'This method has been moved to CloudFlare_Purge');
         $purger = CloudFlare_Purge::create();
-        
+
         return $purger->setResponse($response)->isSuccessful();
     }
 

--- a/code/CloudFlare_ErrorHandlers.php
+++ b/code/CloudFlare_ErrorHandlers.php
@@ -1,6 +1,6 @@
 <?php
 
-class CloudFlare_ErrorHandlers extends Object
+class CloudFlare_ErrorHandlers extends SS_Object
 {
 
     /**

--- a/code/CloudFlare_Notifications.php
+++ b/code/CloudFlare_Notifications.php
@@ -1,6 +1,6 @@
 <?php
 
-class CloudFlare_Notifications extends Object
+class CloudFlare_Notifications extends SS_Object
 {
 
     /**

--- a/code/CloudFlare_Purge.php
+++ b/code/CloudFlare_Purge.php
@@ -1,6 +1,6 @@
 <?php
 
-class CloudFlare_Purge extends Object
+class CloudFlare_Purge extends SS_Object
 {
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.3,<7",
+    "php": "^5.3.3 || ^7",
     "silverstripe/framework": "^3.1.0"
   },
   "prefer-stable": true,

--- a/tests/CloudFlareTest.php
+++ b/tests/CloudFlareTest.php
@@ -34,7 +34,7 @@ class CloudFlareTest extends SapphireTest
      * @param $method
      */
     public function removeExtensibleMethod($method) {
-        $extensions = Object::get_extensions('CloudFlare');
+        $extensions = SS_Object::get_extensions('CloudFlare');
         foreach ($extensions as $class) {
             $tmp = new $class();
             if (method_exists($tmp, $method)) {


### PR DESCRIPTION
This can be used with SilverStripe 3.7; the class_alias provides BC
support for lower 3.x versions.

Note that ideally this would be merged into a new "1" branch created at the point of the current 1.2 tag, so that I can we can it as 1.2.1