### PR TITLE
FIX: Add missing method

### DIFF
--- a/code/CloudFlare.php
+++ b/code/CloudFlare.php
@@ -60,6 +60,15 @@ class CloudFlare extends SS_Object
     }
 
     /**
+     * Checks if the current user has the given permission
+     * @deprecated Use Permission::check instead
+     */
+    public function canUser($permission)
+    {
+        return Permission::check($permission);
+    }
+
+    /**
      * Purges CloudFlare's cache for URL provided.
      *
      * @note The CloudFlare API sets a maximum of 1,200 requests in a five minute period.


### PR DESCRIPTION
This method is called in a couple of places, but doesn’t exist. It
appears to cause 500 errors on publication (after a successful
publish). Not sure if this is meant to work in a different way?

This targets a 1.3.1 release, compatible with ss3.