### PR TITLE
FIX Remove hardcoded Composer package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "steadlane/silverstripe-cloudflare",
   "description": "This module aims to relieve the stress of using CloudFlare caching with any SilverStripe project. Adds extension hooks that clears CloudFlares cache for a specific page when that page is published or unpublished.",
   "type": "silverstripe-module",
-  "version": "1.2",
   "keywords": [
     "cache",
     "cloudflare"


### PR DESCRIPTION
This is unnecessary for Composer, as the Git tag is used instead, and renders tags that don't match the specified version unusable.

This PR is targeted at the 1.x series, which there's no development branch for, so a `1.3` branch will need to be created to re-target this PR at before merging. Would be awesome to get a 1.3.1 release created after merge 🙏 

Resolves #42.